### PR TITLE
Fix memory leak

### DIFF
--- a/hw1/word_count.c
+++ b/hw1/word_count.c
@@ -54,6 +54,7 @@ word_count_t *add_word(word_count_list_t *wclist, char *word) {
   word_count_t *wc = find_word(wclist, word);
   if (wc != NULL) {
     wc->count++;
+    return NULL;
   } else if ((wc = malloc(sizeof(word_count_t))) != NULL) {
     wc->word = word;
     wc->count = 1;


### PR DESCRIPTION
Add word should return null when adding a word that already exists. This signals to the calling function that it should free the word it
added. The free call is https://github.com/Berkeley-CS162/student0/blob/master/hw1/word_helpers.c#L86. 

Tested with valgrind on linux using the following words.txt file
```
aaa bbb aaa aaa aaa aaa
```

Output before
```
==2122== Memcheck, a memory error detector
==2122== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2122== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==2122== Command: ./words words.txt
==2122== 
       1	bbb
       5	aaa
==2122== 
==2122== HEAP SUMMARY:
==2122==     in use at exit: 144 bytes in 8 blocks
==2122==   total heap usage: 11 allocs, 3 frees, 2,168 bytes allocated
==2122== 
==2122== 64 bytes in 4 blocks are definitely lost in loss record 3 of 4
==2122==    at 0x4836753: malloc (in /nix/store/cw09845p8qdy0ajqyj5mj48kilsmj2a8-valgrind-3.15.0/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2122==    by 0x401318: get_word (word_helpers.c:50)
==2122==    by 0x401318: count_words (word_helpers.c:82)
==2122==    by 0x401161: main (words.c:54)
==2122== 
==2122== 80 (24 direct, 56 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 4
==2122==    at 0x4836753: malloc (in /nix/store/cw09845p8qdy0ajqyj5mj48kilsmj2a8-valgrind-3.15.0/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2122==    by 0x401531: add_word (word_count.c:57)
==2122==    by 0x4013C4: count_words (word_helpers.c:85)
==2122==    by 0x401161: main (words.c:54)
==2122== 
==2122== LEAK SUMMARY:
==2122==    definitely lost: 88 bytes in 5 blocks
==2122==    indirectly lost: 56 bytes in 3 blocks
==2122==      possibly lost: 0 bytes in 0 blocks
==2122==    still reachable: 0 bytes in 0 blocks
==2122==         suppressed: 0 bytes in 0 blocks
==2122== 
==2122== For lists of detected and suppressed errors, rerun with: -s
==2122== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)

```

Output after
```
==2832== Memcheck, a memory error detector
==2832== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2832== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==2832== Command: ./words words.txt
==2832== 
       1	bbb
       2	aaa
==2832== 
==2832== HEAP SUMMARY:
==2832==     in use at exit: 80 bytes in 4 blocks
==2832==   total heap usage: 8 allocs, 4 frees, 2,120 bytes allocated
==2832== 
==2832== 80 (24 direct, 56 indirect) bytes in 1 blocks are definitely lost in loss record 3 of 3
==2832==    at 0x4836753: malloc (in /nix/store/cw09845p8qdy0ajqyj5mj48kilsmj2a8-valgrind-3.15.0/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2832==    by 0x40151F: add_word (word_count.c:58)
==2832==    by 0x4013C4: count_words (word_helpers.c:85)
==2832==    by 0x401161: main (words.c:54)
==2832== 
==2832== LEAK SUMMARY:
==2832==    definitely lost: 24 bytes in 1 blocks
==2832==    indirectly lost: 56 bytes in 3 blocks
==2832==      possibly lost: 0 bytes in 0 blocks
==2832==    still reachable: 0 bytes in 0 blocks
==2832==         suppressed: 0 bytes in 0 blocks
==2832== 
==2832== For lists of detected and suppressed errors, rerun with: -s
==2832== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0
```