### PR TITLE
Call tokens_destroy on exit

### DIFF
--- a/hw2/shell.c
+++ b/hw2/shell.c
@@ -55,6 +55,7 @@ int cmd_help(unused struct tokens *tokens) {
 
 /* Exits this shell */
 int cmd_exit(unused struct tokens *tokens) {
+  tokens_destroy(tokens);
   exit(0);
 }
 

--- a/hw2/shell.c
+++ b/hw2/shell.c
@@ -54,7 +54,7 @@ int cmd_help(unused struct tokens *tokens) {
 }
 
 /* Exits this shell */
-int cmd_exit(unused struct tokens *tokens) {
+int cmd_exit(struct tokens *tokens) {
   tokens_destroy(tokens);
   exit(0);
 }


### PR DESCRIPTION
This isn't strictly needed, but without it valgrind will show a several of false positives.